### PR TITLE
feat(tag-appender): Use requirejs to load js files if avail

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
     "_": false,
     "angular": false,
     "require": false,
-    "module": false
+    "module": false,
+    "window": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ angular.module('myApp').config(function (widgetsProvider) {
 
 You must set the manifest generator function in order for the directive to work. This is how we can know for a specific plugin, what files should be loaded and with which module name to create the injector. Above you can see an example for a manifest generator, but you can do whatever you like. You can put both relative and absolute URL's, of course.
 
+*Note:* In case [requirejs](http://requirejs.org/) is available in the global scope, it will be used to load the javascript files. So if your widget needs more than one js file, you can include [requirejs](http://requirejs.org/) and use AMD to load them.
+
 You can actually set multiple manifest generators and they will be evaluated in the order that they were defined. So a generator is allowed to return `undefined` in case it simply wants a different generator to handle it. The way the generators responses are handled is that the last generator that didn't return `undefined` will be used, unless a different generator returned a result with higher `priority`.
 
 ## Service Usage (widget)
@@ -125,7 +127,7 @@ BTW, one event that is shared by default is `$locationChangeStart`. This is in o
 
 ## How to use in the real world
 
-This framework is best used by having a separate project for each widget. During development, the developer sees only his own widget. All widgets should be built in a consistent manner, usually with one concatenated minified .js and .css files. 
+This framework is best used by having a separate project for each widget. During development, the developer sees only his own widget. All widgets should be built in a consistent manner, usually with one concatenated minified .js and .css files.
 
 ## License
 

--- a/app/scripts/services/tag-appender.js
+++ b/app/scripts/services/tag-appender.js
@@ -14,6 +14,10 @@ angular.module('angularWidgetInternal')
 
     return function (url, filetype) {
       var deferred = $q.defer();
+      if (filetype === 'js' && window.requirejs) {
+        window.requirejs([url], deferred.resolve);
+        return deferred.promise;
+      }
       if (requireCache.indexOf(url) !== -1) {
         deferred.resolve();
         return deferred.promise;

--- a/app/scripts/services/tag-appender.js
+++ b/app/scripts/services/tag-appender.js
@@ -15,11 +15,11 @@ angular.module('angularWidgetInternal')
     return function (url, filetype) {
       var deferred = $q.defer();
       if (filetype === 'js' && window.requirejs && headElement === document.getElementsByTagName('head')[0]) {
-        window.requirejs([url], function () {
-          deferred.resolve();
+        window.requirejs([url], function (module) {
+          deferred.resolve(module);
           $rootScope.$digest();
-        }, function () {
-          deferred.reject();
+        }, function (err) {
+          deferred.reject(err);
           $rootScope.$digest();
         });
         return deferred.promise;

--- a/app/scripts/services/tag-appender.js
+++ b/app/scripts/services/tag-appender.js
@@ -14,8 +14,14 @@ angular.module('angularWidgetInternal')
 
     return function (url, filetype) {
       var deferred = $q.defer();
-      if (filetype === 'js' && window.requirejs) {
-        window.requirejs([url], deferred.resolve);
+      if (filetype === 'js' && window.requirejs && headElement === document.getElementsByTagName('head')[0]) {
+        window.requirejs([url], function () {
+          deferred.resolve();
+          $rootScope.$digest();
+        }, function () {
+          deferred.reject();
+          $rootScope.$digest();
+        });
         return deferred.promise;
       }
       if (requireCache.indexOf(url) !== -1) {

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "es5-shim": "~2.1.0",
     "angular-route": ">= 1.2.0",
     "angular-ui-router": "~0.2.11",
-    "angular-widget": "~0.1.30"
+    "angular-widget": "~0.1.30",
+    "requirejs": "~2.1.19"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,6 +33,7 @@ module.exports = function (config) {
       '{app,.tmp}/*.js',
       '{app,.tmp}/scripts/*.js',
       '{app,.tmp}/scripts/*/**/*.js',
+      {pattern:'{,.tmp}/test/mock/mock-lazyloaded-file.js',included:false},
       '{,.tmp/}test/**/*.js',
       '{app,.tmp}/views/**/*.html',
       'app/bower_components/requirejs/require.js'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,7 +34,8 @@ module.exports = function (config) {
       '{app,.tmp}/scripts/*.js',
       '{app,.tmp}/scripts/*/**/*.js',
       '{,.tmp/}test/**/*.js',
-      '{app,.tmp}/views/**/*.html'
+      '{app,.tmp}/views/**/*.html',
+      'app/bower_components/requirejs/require.js'
     ],
 
     // list of files / patterns to exclude

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -47,6 +47,7 @@
     "using": false,
     "pause": false,
     "resume": false,
-    "sleep": false
+    "sleep": false,
+    "window": false
   }
 }

--- a/test/mock/mock-lazyloaded-file.js
+++ b/test/mock/mock-lazyloaded-file.js
@@ -1,0 +1,1 @@
+window.lazyLoadingWorking = true;

--- a/test/spec/services/tag-appender.spec.js
+++ b/test/spec/services/tag-appender.spec.js
@@ -10,6 +10,49 @@ describe('Unit testing tagAppender service', function () {
     });
   });
 
+  describe('Loading with requirejs when available and headElement is head', function () {
+    beforeEach(function () {
+      //Restoring the head element makes requirejs come into action
+      module({
+        headElement: window.document.getElementsByTagName('head')[0]
+      });
+    });
+
+    it('should load the javascript files',  inject (function (tagAppender, $window) {
+      var done = false;
+      tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
+        expect($window.lazyLoadingWorking).toBeTruthy();
+        done = true;
+      });
+      waitsFor(function() {
+        return done;
+      });
+    }));
+
+    it('should fail when file doesn\'t exist', inject (function (tagAppender) {
+      var done = false;
+      tagAppender('base/test/mock/non-existing-file.js', 'js').catch(function () {
+        done = true;
+      });
+      waitsFor(function() {
+        return done;
+      });
+    }));
+
+    it('should not fail when same file loads two times', inject (function (tagAppender, $window) {
+      var done = false;
+      tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
+        tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
+          expect($window.lazyLoadingWorking).toBeTruthy();
+          done= true;
+        });
+      });
+      waitsFor(function() {
+        return done;
+      });
+    }));
+  });
+
   it('should append script tag when js file is added', inject(function (tagAppender) {
     tagAppender('dummy.js', 'js');
     expect(headElement.appendChild.calls.length).toBe(1);

--- a/test/spec/services/tag-appender.spec.js
+++ b/test/spec/services/tag-appender.spec.js
@@ -11,6 +11,9 @@ describe('Unit testing tagAppender service', function () {
   });
 
   describe('Loading with requirejs when available and headElement is head', function () {
+
+    var moduleName = 'base/test/mock/mock-lazyloaded-file.js';
+
     beforeEach(function () {
       //Restoring the head element makes requirejs come into action
       module({
@@ -18,10 +21,16 @@ describe('Unit testing tagAppender service', function () {
       });
     });
 
+    afterEach(inject(function ($window){
+      $window.requirejs.undef(moduleName);
+      $window.lazyLoadingWorking = undefined;
+    }));
+
     it('should load the javascript files',  inject (function (tagAppender, $window) {
       var done = false;
-      tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
-        expect($window.lazyLoadingWorking).toBeTruthy();
+      expect($window.lazyLoadingWorking).toBeFalsy();
+      tagAppender(moduleName, 'js').then(function (mod) {
+        expect($window.lazyLoadingWorking).toBe(true);
         done = true;
       });
       waitsFor(function() {
@@ -41,9 +50,10 @@ describe('Unit testing tagAppender service', function () {
 
     it('should not fail when same file loads two times', inject (function (tagAppender, $window) {
       var done = false;
-      tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
-        tagAppender('base/test/mock/mock-lazyloaded-file.js', 'js').then(function () {
-          expect($window.lazyLoadingWorking).toBeTruthy();
+      expect($window.lazyLoadingWorking).toBeFalsy();
+      tagAppender(moduleName, 'js').then(function () {
+        tagAppender(moduleName, 'js').then(function () {
+          expect($window.lazyLoadingWorking).toBe(true);
           done= true;
         });
       });


### PR DESCRIPTION
I think you should delegate in requirejs when available (or directly depend on it in bower.json and delegate to it all the js loading):
* It is especially designed to do exactly that, loading js files :-).
* It allows the js files to depend one on the others. Check https://github.com/wix/angular-widget/issues/9#issuecomment-121561182. 

I guess it's something that can be achieved by the application by decorating the tagAppender factory, but angular-widget should be able to handle this by itself.

Hope you find this useful.

BTW, I tried to implement it causing the minimum change in the service (if I had used an 'else' statement the diff would have become crazy with the tabs), if you prefer and else statement let me know.